### PR TITLE
run docker container as non root user

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -166,7 +166,7 @@ build-docker|docker-build)
 ;;
 
 docker)
-    docker run --rm -it -v "$PWD":/willow -e TERM "$DOCKER_IMAGE" /bin/bash
+    docker run --user build --rm -it -v "$PWD":/willow -e TERM "$DOCKER_IMAGE" /bin/bash
 ;;
 
 flash)


### PR DESCRIPTION
Running as user 1000 works for many host distros where this is the default user ID and has the benefits that:

- it is docker best practice
- files shared back to the host are non-root ownership so easier to work with

The potential disadvantage is for distros or customisations where the user is not ID 1000. There are various workarounds in this case, but perhaps it might just be made optional and documented? Let me know what you think and I could add that...