### PR TITLE
print the MAC address (e.g. for networks needing registration)

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -664,6 +664,15 @@ static esp_err_t init_input_key_service()
     return periph_service_set_callback(hld_psvc_iks, cb_iks, NULL);
 }
 
+#define MAC_ADDR_SIZE 6
+uint8_t mac_address[6] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55};
+static void get_mac_address()
+{
+    uint8_t mac[MAC_ADDR_SIZE];
+    esp_wifi_get_mac(ESP_IF_WIFI_STA, mac);
+    ESP_LOGI(TAG, "MAC address: %02x:%02x:%02x:%02x:%02x:%02x", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+}
+
 void app_main(void)
 {
     esp_log_level_set("*", ESP_LOG_INFO);
@@ -810,6 +819,8 @@ void app_main(void)
 #ifdef CONFIG_WILLOW_DEBUG_RUNTIME_STATS
     xTaskCreate(&task_debug_runtime_stats, "dbg_runtime_stats", 4 * 1024, NULL, 0, NULL);
 #endif
+
+    get_mac_address(); // should be on wifi by now; print the MAC
 
     while (true) {
 #ifdef CONFIG_WILLOW_DEBUG_MEM


### PR DESCRIPTION
Code from https://github.com/espressif/esp-idf/blob/master/examples/system/base_mac_address/main/base_mac_address_example_main.c to print out the WiFi MAC address (e.g. if using a network that requires pre-registration of devices).

(Take 2, clean and shiney, I hope! Sorry for the hassle.)