### PR TITLE
main: trigger WAKE_END right after VAD_END

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -507,7 +507,7 @@ static void start_rec()
         .wakeup_time = AUDIO_REC_DEF_WAKEUP_TM,
         .vad_start = AUDIO_REC_VAD_START_SPEECH_MS,
         .vad_off = 300,
-        .wakeup_end = 100,
+        .wakeup_end = 1,
         .encoder_handle = NULL,
         .encoder_iface = NULL,
     };


### PR DESCRIPTION
In 086dfc0fd22d ("main: trigger WAKEUP_END shortly after VAD_END"), we reduced the time between VAD_END and WAKEUP_END from 900ms to 100ms, and noted that setting it to 0 caused very weird behaviour. In further testing, we learned that setting it to 1 does not result in that same weird behaviour, so let's set it to 1 and shave of another 99ms of the response time.