### PR TITLE
Use default record ringbuffer values when using multinet

### DIFF
--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -121,6 +121,7 @@ config WILLOW_VAD_TIMEOUT
         Allows for entering 1 - 1000 ms but if you go lower than 50 or so good luck...
 
 config WILLOW_RECORD_BUFFER
+    depends on !WILLOW_USE_MULTINET
     int "Record buffer"
     range 1 16
     default 12

--- a/main/main.c
+++ b/main/main.c
@@ -461,14 +461,15 @@ static void start_rec()
         .mn_language = ESP_MN_ENGLISH,
     };
 
-#ifdef CONFIG_WILLOW_USE_MULTINET
-    ESP_LOGI(TAG, "Using local multinet");
-    cfg_srr.multinet_init = true;
-#endif
-
 #ifdef CONFIG_WILLOW_RECORD_BUFFER
     ESP_LOGI(TAG, "Using record buffer '%d'", CONFIG_WILLOW_RECORD_BUFFER);
     cfg_srr.rb_size = CONFIG_WILLOW_RECORD_BUFFER * 1024;
+#endif
+
+#ifdef CONFIG_WILLOW_USE_MULTINET
+    ESP_LOGI(TAG, "Using local multinet");
+    cfg_srr.multinet_init = true;
+    cfg_srr.rb_size = 6 * 1024;
 #endif
 
 #ifdef CONFIG_WILLOW_USE_AMRWB


### PR DESCRIPTION
When user server mode speech rec we increase (or allow the user to specify) the ADF record buffer due to potential internet latency and other timing issues.

This is a non-factor with local multinet command recognition so it's probably best to use the default values to avoid any potential edge cases.