### PR TITLE
ignore .DS_Store and .vscode for easier coordination with other dev PRs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ target
 willow-dist.bin
 .env
 serve
+.DS_Store
+.vscode


### PR DESCRIPTION
.DS_Store is a macOS file that can get added to repos if devs are not paying attention and .vscode is for the local Visual Studio Code settings.