### PR TITLE
Updated Dockerfile ENV to ARG

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM espressif/idf:release-v4.4
 
-ENV DEBIAN_FRONTEND="noninteractive"
+ARG DEBIAN_FRONTEND="noninteractive"
 
 RUN apt-get -qq update && \
 	apt-get -qq install \


### PR DESCRIPTION
Setting DEBIAN_FRONTEND=noninteractive via ENV is discouraged as it will persist in the final docker container when it is run. Using ARG here only exports this variable for the build steps.