### PR TITLE
Kconfig: expose wake modes

### DIFF
--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -233,4 +233,29 @@ config WILLOW_STREAM_TIMEOUT
 
     endmenu
 
+    menu "Advanced settings"
+        choice WILLOW_WAKE_MODE
+            prompt "Wake Word Recognition Operating Mode"
+            default WILLOW_WAKE_DET_MODE_2CH_90
+
+                config WILLOW_WAKE_DET_MODE_90
+                    bool "DET_MODE_90"
+
+                config WILLOW_WAKE_DET_MODE_95
+                    bool "DET_MODE_95"
+
+                config WILLOW_WAKE_DET_MODE_2CH_90
+                    bool "DET_MODE_2CH_90"
+
+                config WILLOW_WAKE_DET_MODE_2CH_95
+                    bool "DET_MODE_2CH_95"
+
+                config WILLOW_WAKE_DET_MODE_3CH_90
+                    bool "DET_MODE_3CH_90"
+
+                config WILLOW_WAKE_DET_MODE_3CH_95
+                    bool "DET_MODE_3CH_95"
+        endchoice
+    endmenu
+
 endmenu

--- a/main/main.c
+++ b/main/main.c
@@ -455,7 +455,19 @@ static void start_rec()
         .voice_communication_agc_gain = 15,
         .vad_mode = VAD_MODE_3,
         .wakenet_model_name = NULL,
+#if defined(CONFIG_WILLOW_WAKE_DET_MODE_2CH_90)
         .wakenet_mode = DET_MODE_2CH_90,
+#elif defined(CONFIG_WILLOW_WAKE_DET_MODE_2CH_95)
+        .wakenet_mode = DET_MODE_2CH_95,
+#elif defined(CONFIG_WILLOW_WAKE_DET_MODE_90)
+        .wakenet_mode = DET_MODE_90,
+#elif defined(CONFIG_WILLOW_WAKE_DET_MODE_95)
+        .wakenet_mode = DET_MODE_95,
+#elif defined(CONFIG_WILLOW_WAKE_DET_MODE_3CH_90)
+        .wakenet_mode = DET_MODE_3CH_90,
+#elif defined(CONFIG_WILLOW_WAKE_DET_MODE_3CH_95)
+        .wakenet_mode = DET_MODE_3CH_95,
+#endif
         .afe_mode = SR_MODE_HIGH_PERF,
         .afe_perferred_core = 1,
         .afe_perferred_priority = 5,


### PR DESCRIPTION
This should allow people experiencing problems with the wake word to experiment with different accuracy.

Related to #111.

As this is something that should only be changed if instructed by us, move it in an "Advanced settings" submenu.