### PR TITLE
Kconfig: add option for microphone gain

### DIFF
--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -272,6 +272,74 @@ config WILLOW_NTP_HOST
                 config WILLOW_WAKE_DET_MODE_3CH_95
                     bool "DET_MODE_3CH_95"
         endchoice
+
+        choice
+            prompt "Microphone gain"
+            default WILLOW_MIC_GAIN_37_5DB
+
+                config WILLOW_MIC_GAIN_0DB
+                    bool "0 dB"
+
+                config WILLOW_MIC_GAIN_3DB
+                    bool "3 dB"
+
+                config WILLOW_MIC_GAIN_6DB
+                    bool "6 dB"
+
+                config WILLOW_MIC_GAIN_9DB
+                    bool "9 dB"
+
+                config WILLOW_MIC_GAIN_12DB
+                    bool "12 dB"
+
+                config WILLOW_MIC_GAIN_15DB
+                    bool "15 dB"
+
+                config WILLOW_MIC_GAIN_18DB
+                    bool "18 dB"
+
+                config WILLOW_MIC_GAIN_21DB
+                    bool "21 dB"
+
+                config WILLOW_MIC_GAIN_24DB
+                    bool "24 dB"
+
+                config WILLOW_MIC_GAIN_27DB
+                    bool "27 dB"
+
+                config WILLOW_MIC_GAIN_30DB
+                    bool "30 dB"
+
+                config WILLOW_MIC_GAIN_33DB
+                    bool "33 dB"
+
+                config WILLOW_MIC_GAIN_34_5DB
+                    bool "34.5 dB"
+
+                config WILLOW_MIC_GAIN_36DB
+                    bool "36 dB"
+
+                config WILLOW_MIC_GAIN_37_5DB
+                    bool "37.5 dB"
+        endchoice
+
+        config WILLOW_MIC_GAIN
+            int
+            default 0 if WILLOW_MIC_GAIN_0DB
+            default 1 if WILLOW_MIC_GAIN_3DB
+            default 2 if WILLOW_MIC_GAIN_6DB
+            default 3 if WILLOW_MIC_GAIN_9DB
+            default 4 if WILLOW_MIC_GAIN_12DB
+            default 5 if WILLOW_MIC_GAIN_15DB
+            default 6 if WILLOW_MIC_GAIN_18DB
+            default 7 if WILLOW_MIC_GAIN_21DB
+            default 8 if WILLOW_MIC_GAIN_24DB
+            default 9 if WILLOW_MIC_GAIN_27DB
+            default 10 if WILLOW_MIC_GAIN_30DB
+            default 11 if WILLOW_MIC_GAIN_33DB
+            default 12 if WILLOW_MIC_GAIN_34_5DB
+            default 13 if WILLOW_MIC_GAIN_36DB
+            default 14 if WILLOW_MIC_GAIN_37_5DB
     endmenu
 
     menu "Debugging"

--- a/main/main.c
+++ b/main/main.c
@@ -212,7 +212,7 @@ static esp_err_t cb_iks(periph_service_handle_t hdl, periph_service_event_t *ev,
             };
 
             es7210_adc_init(&cfg_ahc);
-            es7210_adc_set_gain(GAIN_37_5DB);
+            es7210_adc_set_gain(CONFIG_WILLOW_MIC_GAIN);
         }
     }
 
@@ -941,6 +941,7 @@ void app_main(void)
     init_esp_audio(hdl_audio_board);
     init_spiffs_audio();
     start_rec();
+    es7210_adc_set_gain(CONFIG_WILLOW_MIC_GAIN);
 
     ESP_LOGI(TAG, "app_main() - start_rec() finished");
 


### PR DESCRIPTION
Use a hidden int with default based on the selected choice. This mimics the gain_value enum in es7210.h. This is cleaner than using ifdef.