### PR TITLE
Enable TTS audio response from generic REST endpoints

### DIFF
--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -183,6 +183,13 @@ config WILLOW_ENDPOINT_REST_AUTH_PASSWORD
     depends on WILLOW_ENDPOINT_REST_AUTH_BASIC
     string "Password for HTTP Basic Authentication"
 
+config WILLOW_ENDPOINT_REST_SPEECH_MAX_LEN
+    int "Generic REST endpoint max TTS length"
+    range 64 1024
+    default 64
+    help
+        Max characters in the spoken response from the REST endpoint
+
 config WILLOW_TIMEZONE
     string "Timezone"
     default "UTC+5"


### PR DESCRIPTION
**Enable TTS audio response** from REST endpoints by checking for a message field in POST responses and passing it to the audio response fn_ok.

**Add a configuration option** to specify the maximum length of the text to send to TTS in this way.

**Background**: for HomeAssistant the response can be read out on the ESP BOX. To enable external REST APIs to do that we need to add a little code to `rest.c` (following the way it is done in `hass.c`).