### PR TITLE
optional chime on wakeword detection

### DIFF
--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -218,6 +218,12 @@ choice WILLOW_NTP
             Override NTP server with host provided via DHCP
 endchoice
 
+config WILLOW_CHIME_ON_WAKE
+    bool "Play a chime when the wake word is recognised"
+    default n
+    help
+        Plays a chime tone when waking
+
 config WILLOW_NTP_HOST
     depends on WILLOW_NTP_USE_HOST
     string "Willow NTP host"

--- a/main/audio.c
+++ b/main/audio.c
@@ -155,3 +155,12 @@ void init_esp_audio(audio_board_handle_t hdl)
     esp_audio_vol_set(hdl_ea, CONFIG_WILLOW_VOLUME);
     ESP_LOGI(TAG, "audio player initialized");
 }
+
+#ifdef CONFIG_WILLOW_CHIME_ON_WAKE
+void play_chime(void)
+{
+    gpio_set_level(get_pa_enable_gpio(), 1);
+    esp_audio_sync_play(hdl_ea, "spiffs://spiffs/ui/success.flac", 0);
+    gpio_set_level(get_pa_enable_gpio(), 0);
+}
+#endif

--- a/main/audio.h
+++ b/main/audio.h
@@ -1,2 +1,5 @@
 void init_audio_response(void);
 void init_esp_audio(audio_board_handle_t hdl);
+#ifdef CONFIG_WILLOW_CHIME_ON_WAKE
+void play_chime(void);
+#endif

--- a/main/main.c
+++ b/main/main.c
@@ -123,6 +123,9 @@ static esp_err_t cb_ar_event(audio_rec_evt_t are, void *data)
                 xQueueSend(q_rec, &msg, 0);
                 break;
             }
+#ifdef CONFIG_WILLOW_CHIME_ON_WAKE
+            play_chime();
+#endif
             reset_timer(hdl_display_timer, DISPLAY_TIMEOUT_US, true);
             lvgl_port_lock(0);
             lv_obj_add_flag(lbl_ln1, LV_OBJ_FLAG_HIDDEN);


### PR DESCRIPTION
Resolve #147 by playing the "success.flac" chime tone when waking. Configurable via `./utils config` in the usual (pre-WAS?) way.