### PR TITLE
Revert "treewide: disable text LVGL text scrolling"

### DIFF
--- a/main/audio.c
+++ b/main/audio.c
@@ -853,8 +853,8 @@ void init_audio(void)
             lv_obj_add_flag(lbl_ln4, LV_OBJ_FLAG_HIDDEN);
             lv_obj_align(lbl_ln4, LV_ALIGN_TOP_LEFT, 0, 120);
             lv_obj_set_width(lbl_ln5, 320);
-            lv_label_set_long_mode(lbl_ln1, LV_LABEL_LONG_CLIP);
-            lv_label_set_long_mode(lbl_ln5, LV_LABEL_LONG_CLIP);
+            lv_label_set_long_mode(lbl_ln1, LV_LABEL_LONG_SCROLL);
+            lv_label_set_long_mode(lbl_ln5, LV_LABEL_LONG_SCROLL);
             lv_label_set_text(lbl_ln3, wake_help);
 
             lvgl_port_unlock();

--- a/main/ui.c
+++ b/main/ui.c
@@ -82,7 +82,7 @@ void init_ui(void)
             lv_obj_align(lbl_ln3, LV_ALIGN_TOP_MID, 0, 90);
             lv_obj_align(lbl_ln4, LV_ALIGN_TOP_MID, 0, 120);
             lv_obj_align(lbl_ln5, LV_ALIGN_TOP_LEFT, 0, 150);
-            lv_label_set_long_mode(lbl_ln2, LV_LABEL_LONG_CLIP);
+            lv_label_set_long_mode(lbl_ln2, LV_LABEL_LONG_SCROLL);
             lv_obj_set_width(lbl_ln2, 320);
 
             if (strcmp(speech_rec_mode, "Multinet") == 0) {


### PR DESCRIPTION
We previously disabled LVGL text scrolling to test if this would fix the display locking up, but we kept experiencing the lockups. We believe commit c8561a1076be ("sdkconfig: enable LCD_RGB_ISR_IRAM_SAFE") finally fixed the problem.

We do not want to risk this causing problems in the 0.1.0 release again, but now that we've branched release/v0.1, let's enable text scrolling again in main.

This reverts commit 5b46dbd7da9cff4945b6e93a6b134e709b06ce45.