### PR TITLE
Print "Thinking..." on the display after speech while command is sent

### DIFF
--- a/main/audio.c
+++ b/main/audio.c
@@ -274,6 +274,10 @@ static esp_err_t cb_ar_event(audio_rec_evt_t are, void *data)
             ESP_LOGI(TAG, "AUDIO_REC_WAKEUP_END");
             msg = MSG_STOP;
             xQueueSend(q_rec, &msg, 0);
+            if (lvgl_port_lock(lvgl_lock_timeout)) {
+                lv_label_set_text_static(lbl_ln3, "Thinking...");
+                lvgl_port_unlock();
+            }
             break;
         case AUDIO_REC_WAKEUP_START:
             ESP_LOGI(TAG, "AUDIO_REC_WAKEUP_START");


### PR DESCRIPTION
Continuing to display "Say Command..." after speech has ended and the command has been sent to the command endpoint is poor and confusing UI. Print "Thinking..." after speech has ended while we're waiting for response.

Fixes #247 