### PR TITLE
backport: treewide: use commit hash for ESP-ADF

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY container.gitconfig /root/.gitconfig
 ENV PATH="$PATH:/willow/.local/bin"
 WORKDIR /willow
 
-ENV ADF_VER="willow"
+ENV ADF_VER="5cb9820cc1070e629d3439839f4449a61d3c53d6"
 RUN \
     cd /opt/esp/idf && \
     curl https://raw.githubusercontent.com/toverainc/esp-adf/$ADF_VER/idf_patches/idf_v4.4_freertos.patch | patch -p1

--- a/utils.sh
+++ b/utils.sh
@@ -172,8 +172,9 @@ install() {
     mkdir -p deps
     cd deps
     # Setup ADF
-    git clone -b "$ADF_VER" https://github.com/toverainc/esp-adf.git
+    git clone https://github.com/toverainc/esp-adf.git
     cd $ADF_PATH
+    git checkout "$ADF_VER"
     git submodule update --init components/esp-adf-libs
 
     # Setup esp-sr


### PR DESCRIPTION
We currently point to the willow branch of our ESP-ADF fork. As long as we don't update that branch, this is fine, but once this branch gets updated, rebuilding Willow would result in a different binary, even when building a tag. This makes bisecting near impossible.

Use a commit hash instead of a branch name to avoid above problems.

(cherry picked from commit 2d0b90a8d625c07ab24e147cf6711cdccdbfb700)