### PR TITLE
Standardize user experience across across all supported command endpoints.

### DIFF
--- a/main/audio.c
+++ b/main/audio.c
@@ -453,6 +453,11 @@ static esp_err_t hdl_ev_hs(http_stream_event_msg_t *msg)
             }
             buf[read_len] = 0;
             ESP_LOGI(TAG, "WIS HTTP Response = %s", (char *)buf);
+            if (lvgl_port_lock(lvgl_lock_timeout)) {
+                lv_obj_add_flag(lbl_ln3, LV_OBJ_FLAG_HIDDEN);
+                lv_obj_add_flag(lbl_ln4, LV_OBJ_FLAG_HIDDEN);
+                lvgl_port_unlock();
+            }
             char *command_endpoint = config_get_char("command_endpoint", DEFAULT_COMMAND_ENDPOINT);
             if (strcmp(command_endpoint, "Home Assistant") == 0) {
                 hass_send(buf);
@@ -470,8 +475,6 @@ static esp_err_t hdl_ev_hs(http_stream_event_msg_t *msg)
             if (lvgl_port_lock(lvgl_lock_timeout)) {
                 lv_obj_clear_flag(lbl_ln1, LV_OBJ_FLAG_HIDDEN);
                 lv_obj_clear_flag(lbl_ln2, LV_OBJ_FLAG_HIDDEN);
-                lv_obj_add_flag(lbl_ln3, LV_OBJ_FLAG_HIDDEN);
-                lv_obj_add_flag(lbl_ln4, LV_OBJ_FLAG_HIDDEN);
                 if (cJSON_IsString(speaker_status) && speaker_status->valuestring != NULL) {
                     lv_label_set_text(lbl_ln1, speaker_status->valuestring);
                 } else {

--- a/main/endpoint/hass.c
+++ b/main/endpoint/hass.c
@@ -144,7 +144,7 @@ end:
                 if (hir.has_speech) {
                     hir.ok ? war.fn_ok(hir.speech) : war.fn_err(hir.speech);
                 } else {
-                    hir.ok ? war.fn_ok("success") : war.fn_err("error");
+                    hir.ok ? war.fn_ok("Success") : war.fn_err("Error");
                 }
 
                 if (lvgl_port_lock(lvgl_lock_timeout)) {
@@ -156,7 +156,7 @@ end:
                         lv_label_set_text(lbl_ln5, hir.speech);
                     } else {
                         lv_label_set_text_static(lbl_ln4, "Command status:");
-                        lv_label_set_text(lbl_ln5, hir.ok ? "#008000 Success!" : "#ff0000 Error!");
+                        lv_label_set_text(lbl_ln5, hir.ok ? "Success!" : "Error");
                     }
                     lvgl_port_unlock();
                 }
@@ -357,10 +357,10 @@ http_error:
         lv_obj_remove_event_cb(lbl_ln4, cb_btn_cancel);
         if (http_status == 200) {
             lv_label_set_text_static(lbl_ln4, "Command status:");
-            lv_label_set_text(lbl_ln5, ok ? "#008000 Success!" : "#ff0000 No Matching HA Intent");
+            lv_label_set_text(lbl_ln5, ok ? "Success!" : "No Matching HA Intent");
         } else {
             lv_label_set_text_static(lbl_ln4, "Error contacting HASS:");
-            lv_label_set_text_fmt(lbl_ln5, "#ff0000 HTTP %d", http_status);
+            lv_label_set_text_fmt(lbl_ln5, "HTTP %d", http_status);
         }
 
         lvgl_port_unlock();

--- a/main/endpoint/openhab.c
+++ b/main/endpoint/openhab.c
@@ -63,9 +63,9 @@ void openhab_send(const char *data)
 end:
     free(url);
     if (ok) {
-        war.fn_ok("ok");
+        war.fn_ok("Success");
     } else {
-        war.fn_err("error");
+        war.fn_err("Error");
     }
 
     if (body != NULL && strlen(body) > 1) {
@@ -75,12 +75,12 @@ end:
     if (lvgl_port_lock(lvgl_lock_timeout)) {
         lv_obj_clear_flag(lbl_ln4, LV_OBJ_FLAG_HIDDEN);
         lv_obj_clear_flag(lbl_ln5, LV_OBJ_FLAG_HIDDEN);
-        lv_label_set_text_static(lbl_ln4, "Command status:");
         lv_obj_remove_event_cb(lbl_ln4, cb_btn_cancel);
+        lv_label_set_text_static(lbl_ln4, "Command status:");
         if (body != NULL && strlen(body) > 1) {
             lv_label_set_text(lbl_ln5, body);
         } else {
-            lv_label_set_text(lbl_ln5, ok ? "#008000 Success!" : "#ff0000 Error");
+            lv_label_set_text(lbl_ln5, ok ? "Success!" : "Error");
         }
         lvgl_port_unlock();
     }

--- a/main/endpoint/rest.c
+++ b/main/endpoint/rest.c
@@ -70,7 +70,7 @@ void rest_send(const char *data)
         }
     } else {
         ESP_LOGI(TAG, "REST failed");
-        war.fn_err("Something went wrong");
+        war.fn_err("Error");
     }
 
     if (lvgl_port_lock(lvgl_lock_timeout)) {
@@ -82,7 +82,7 @@ void rest_send(const char *data)
             lv_label_set_text(lbl_ln5, body);
         } else {
             lv_label_set_text_static(lbl_ln4, "Command status:");
-            lv_label_set_text(lbl_ln5, ok ? "#008000 Success!" : "#ff0000 Error");
+            lv_label_set_text(lbl_ln5, ok ? "Success!" : "Error");
         }
         lvgl_port_unlock();
     }

--- a/main/endpoint/rest.c
+++ b/main/endpoint/rest.c
@@ -66,7 +66,7 @@ void rest_send(const char *data)
         war.fn_err("error");
     }
 
-    if (strlen(body) > 1) {
+    if (body != NULL && strlen(body) > 1) {
         ESP_LOGI(TAG, "REST response: %s", body);
     }
 
@@ -75,7 +75,7 @@ void rest_send(const char *data)
         lv_obj_clear_flag(lbl_ln5, LV_OBJ_FLAG_HIDDEN);
         lv_label_set_text_static(lbl_ln4, "Command status:");
         lv_obj_remove_event_cb(lbl_ln4, cb_btn_cancel);
-        if (strlen(body) > 1) {
+        if (body != NULL && strlen(body) > 1) {
             lv_label_set_text(lbl_ln5, body);
         } else {
             lv_label_set_text(lbl_ln5, ok ? "#008000 Success!" : "#ff0000 Error");

--- a/main/endpoint/rest.c
+++ b/main/endpoint/rest.c
@@ -61,23 +61,27 @@ void rest_send(const char *data)
     }
 
     if (ok) {
-        war.fn_ok("ok");
+        if (body != NULL && strlen(body) > 1) {
+            ESP_LOGI(TAG, "REST response: %s", body);
+            war.fn_ok(body);
+        } else {
+            ESP_LOGI(TAG, "REST successful");
+            war.fn_ok("Success");
+        }
     } else {
-        war.fn_err("error");
-    }
-
-    if (body != NULL && strlen(body) > 1) {
-        ESP_LOGI(TAG, "REST response: %s", body);
+        ESP_LOGI(TAG, "REST failed");
+        war.fn_err("Something went wrong");
     }
 
     if (lvgl_port_lock(lvgl_lock_timeout)) {
         lv_obj_clear_flag(lbl_ln4, LV_OBJ_FLAG_HIDDEN);
         lv_obj_clear_flag(lbl_ln5, LV_OBJ_FLAG_HIDDEN);
-        lv_label_set_text_static(lbl_ln4, "Command status:");
         lv_obj_remove_event_cb(lbl_ln4, cb_btn_cancel);
         if (body != NULL && strlen(body) > 1) {
+            lv_label_set_text_static(lbl_ln4, "Response:");
             lv_label_set_text(lbl_ln5, body);
         } else {
+            lv_label_set_text_static(lbl_ln4, "Command status:");
             lv_label_set_text(lbl_ln5, ok ? "#008000 Success!" : "#ff0000 Error");
         }
         lvgl_port_unlock();


### PR DESCRIPTION
Across our various command endpoints there is currently a lot of inconsistency in terms of user experience:

1) Some status lines still use red/green to communicate feedback. These are very low-contrast against our current purple background.

2) REST doesn't support TTS responses.

3) OpenHAB doesn't support TTS responses.

4) There is inconsistent language all over the place for generic responses - sometimes saying/display "Error!", other times "Error", etc.

5) REST and OpenHAB endpoints don't display the Response: text on LVGL line 4

This PR addresses these issues to bring a more consistent user experience across all supported command endpoints.