### PR TITLE
Initial multiwake support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY container.gitconfig /root/.gitconfig
 ENV PATH="$PATH:/willow/.local/bin"
 WORKDIR /willow
 
-ENV ADF_VER="willow-main-2023091400"
+ENV ADF_VER="willow-main-2023091500"
 RUN \
     cd /opt/esp/idf && \
     curl https://raw.githubusercontent.com/toverainc/esp-adf/$ADF_VER/idf_patches/idf_v4.4_freertos.patch | patch -p1

--- a/main/audio.c
+++ b/main/audio.c
@@ -275,10 +275,6 @@ static esp_err_t cb_ar_event(audio_rec_evt_t are, void *data)
             ESP_LOGI(TAG, "AUDIO_REC_WAKEUP_END");
             msg = MSG_STOP;
             xQueueSend(q_rec, &msg, 0);
-            if (lvgl_port_lock(lvgl_lock_timeout)) {
-                lv_label_set_text_static(lbl_ln3, "Thinking...");
-                lvgl_port_unlock();
-            }
             break;
         case AUDIO_REC_WAKEUP_START:
             ESP_LOGI(TAG, "AUDIO_REC_WAKEUP_START");
@@ -760,6 +756,7 @@ static void at_read(void *data)
                     recording = false;
                     stream_to_api = false;
                     if (lvgl_port_lock(lvgl_lock_timeout)) {
+                        lv_label_set_text_static(lbl_ln3, "Thinking...");
                         lv_obj_add_flag(btn_cancel, LV_OBJ_FLAG_HIDDEN);
                         lvgl_port_unlock();
                     }

--- a/main/audio.c
+++ b/main/audio.c
@@ -285,6 +285,13 @@ static esp_err_t cb_ar_event(audio_rec_evt_t are, void *data)
             if (recording) {
                 break;
             }
+            float *wake_volume_ptr = (float *)data;
+            if (wake_volume_ptr == NULL) {
+                ESP_LOGI(TAG, "wake_volume_ptr is NULL");
+            } else {
+                float wake_volume = *wake_volume_ptr;
+                ESP_LOGI(TAG, "wake volume: %f", wake_volume);
+            }
             reset_timer(hdl_display_timer, DISPLAY_TIMEOUT_US, true);
 
             speech_rec_mode = config_get_char("speech_rec_mode", DEFAULT_SPEECH_REC_MODE);

--- a/main/audio.c
+++ b/main/audio.c
@@ -283,6 +283,8 @@ static esp_err_t cb_ar_event(audio_rec_evt_t are, void *data)
             if (recording) {
                 break;
             }
+            // win by default so in case WAS multiwake handling goes wrong we act normally
+            multiwake_won = true;
             float *wake_volume_ptr = (float *)data;
             if (wake_volume_ptr == NULL) {
                 ESP_LOGI(TAG, "wake_volume_ptr is NULL");
@@ -759,7 +761,7 @@ static void at_read(void *data)
                     recording = false;
                     stream_to_api = false;
                     if (lvgl_port_lock(lvgl_lock_timeout)) {
-                        lv_label_set_text_static(lbl_ln3, "Thinking...");
+                        lv_label_set_text_static(lbl_ln3, multiwake_won ? "Thinking..." : "WOW Active - Exiting");
                         lv_obj_add_flag(btn_cancel, LV_OBJ_FLAG_HIDDEN);
                         lvgl_port_unlock();
                     }

--- a/main/audio.c
+++ b/main/audio.c
@@ -31,6 +31,7 @@
 #include "slvgl.h"
 #include "timer.h"
 #include "ui.h"
+#include "was.h"
 
 #include "endpoint/hass.h"
 #include "endpoint/openhab.h"
@@ -275,6 +276,7 @@ static esp_err_t cb_ar_event(audio_rec_evt_t are, void *data)
             ESP_LOGI(TAG, "AUDIO_REC_WAKEUP_END");
             msg = MSG_STOP;
             xQueueSend(q_rec, &msg, 0);
+            send_wake_end();
             break;
         case AUDIO_REC_WAKEUP_START:
             ESP_LOGI(TAG, "AUDIO_REC_WAKEUP_START");
@@ -287,6 +289,7 @@ static esp_err_t cb_ar_event(audio_rec_evt_t are, void *data)
             } else {
                 float wake_volume = *wake_volume_ptr;
                 ESP_LOGI(TAG, "wake volume: %f", wake_volume);
+                send_wake_start(wake_volume);
             }
             reset_timer(hdl_display_timer, DISPLAY_TIMEOUT_US, true);
 

--- a/main/audio.h
+++ b/main/audio.h
@@ -13,6 +13,7 @@ typedef enum {
 } q_msg;
 
 audio_rec_handle_t hdl_ar;
+volatile bool multiwake_won;
 volatile bool recording;
 esp_audio_handle_t hdl_ea;
 extern QueueHandle_t q_rec;

--- a/main/log.c
+++ b/main/log.c
@@ -12,6 +12,7 @@ void init_logging(void)
     esp_log_level_set("*", ESP_LOG_DEBUG);
 #else
     esp_log_level_set("*", ESP_LOG_ERROR);
+    esp_log_level_set("AUDIO_RECORDER", ESP_LOG_INFO);
     esp_log_level_set("PERIPH_WIFI", ESP_LOG_WARN);
 #endif
 

--- a/main/was.c
+++ b/main/was.c
@@ -302,6 +302,11 @@ void send_wake_start(float wake_volume)
     char *json;
     esp_err_t ret;
 
+    // Silently return if multiwake is not enabled - defaults to not enabled
+    if (!config_get_bool("multiwake", false)) {
+        return;
+    }
+
     if (!esp_websocket_client_is_connected(hdl_wc)) {
         ESP_LOGW(TAG, "Websocket not connected - skipping wake start");
         return;
@@ -333,6 +338,11 @@ void send_wake_end(void)
 {
     char *json;
     esp_err_t ret;
+
+    // Silently return if multiwake is not enabled - defaults to not enabled
+    if (!config_get_bool("multiwake", false)) {
+        return;
+    }
 
     if (!esp_websocket_client_is_connected(hdl_wc)) {
         ESP_LOGW(TAG, "Websocket not connected - skipping wake end");

--- a/main/was.c
+++ b/main/was.c
@@ -282,3 +282,64 @@ static void send_hello(void)
 cleanup:
     cJSON_Delete(cjson);
 }
+
+void send_wake_start(float wake_volume)
+{
+    char *json;
+    esp_err_t ret;
+
+    if (!esp_websocket_client_is_connected(hdl_wc)) {
+        ESP_LOGW(TAG, "Websocket not connected - skipping wake start");
+        return;
+    }
+
+    cJSON *cjson = cJSON_CreateObject();
+    cJSON *wake_start = cJSON_CreateObject();
+
+    if (!cJSON_AddNumberToObject(wake_start, "wake_volume", wake_volume)) {
+        goto cleanup;
+    }
+    if (!cJSON_AddItemToObject(cjson, "wake_start", wake_start)) {
+        goto cleanup;
+    }
+
+    json = cJSON_Print(cjson);
+
+    ret = esp_websocket_client_send_text(hdl_wc, json, strlen(json), 2000 / portTICK_PERIOD_MS);
+    cJSON_free(json);
+    if (ret < 0) {
+        ESP_LOGE(TAG, "failed to send WAS wake_start message");
+    }
+
+cleanup:
+    cJSON_Delete(cjson);
+}
+
+void send_wake_end(void)
+{
+    char *json;
+    esp_err_t ret;
+
+    if (!esp_websocket_client_is_connected(hdl_wc)) {
+        ESP_LOGW(TAG, "Websocket not connected - skipping wake end");
+        return;
+    }
+
+    cJSON *cjson = cJSON_CreateObject();
+    cJSON *wake_end = cJSON_CreateObject();
+
+    if (!cJSON_AddItemToObject(cjson, "wake_end", wake_end)) {
+        goto cleanup;
+    }
+
+    json = cJSON_Print(cjson);
+
+    ret = esp_websocket_client_send_text(hdl_wc, json, strlen(json), 2000 / portTICK_PERIOD_MS);
+    cJSON_free(json);
+    if (ret < 0) {
+        ESP_LOGE(TAG, "failed to send WAS wake_end message");
+    }
+
+cleanup:
+    cJSON_Delete(cjson);
+}

--- a/main/was.h
+++ b/main/was.h
@@ -3,3 +3,5 @@ char was_url[2048];
 void deinit_was(void);
 esp_err_t init_was(void);
 void request_config(void);
+void send_wake_start(float wake_volume);
+void send_wake_end(void);


### PR DESCRIPTION
This PR implements handling of multiple Willow devices waking at the same time. With WAS support, only the Willow device with the highest wake word volume will send a command to the endpoint. Without WAS support, Willow will function like before.

It is possible to trigger VAD START before the wake_result is received from WAS, which will cause Willow devices who have lost the wake race to start streaming to WIS already. This should be improved, but will require some refactoring. For now, this should be good enough to demonstrate the feature, but the feature should be considered experimental.