### PR TITLE
CI: build from correct container image tag

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -3,16 +3,23 @@ name: build-container
 
 env:
   GH_TOKEN: ${{ github.token }}
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 
-on: workflow_call
+on:
+  workflow_call:
+    inputs:
+      container-image:
+        required: true
+        type: string
+      labels:
+        required: true
+        type: string
+      tags:
+        required: true
+        type: string
 
 jobs:
   build-container:
     runs-on: ubuntu-22.04
-    outputs:
-      json: ${{ steps.metadata.outputs.json }}
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -20,19 +27,9 @@ jobs:
       - name: login to ghcr.io
         uses: docker/login-action@v2
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: extract metadata
-        id: metadata
-        uses: docker/metadata-action@v4
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=ref,event=tag
-            type=ref,event=pr
-            type=ref,event=branch
 
       - name: build container
         uses: docker/build-push-action@v4
@@ -40,14 +37,11 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          labels: ${{ steps.metadata.outputs.labels }}
-          tags: ${{ steps.metadata.outputs.tags }}
-
-      - name: debug
-        run: echo "${{ fromJSON(steps.metadata.outputs.json).tags[0] }}"
+          labels: ${{ inputs.labels }}
+          tags: ${{ inputs.tags }}
 
   build-willow:
     uses: ./.github/workflows/build-willow.yml
     needs: build-container
     with:
-      container-image: ${{ fromJSON(needs.build-container.outputs.json).tags[0] }}
+      container-image: ${{ inputs.container-image }}

--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -15,6 +15,9 @@ jobs:
     outputs:
       container_any_changed: ${{ steps.changed_files_yaml.outputs.container_any_changed }}
       image_any_changed: ${{ steps.changed_files_yaml.outputs.image_any_changed }}
+      metadata_json: ${{ steps.metadata.outputs.json }}
+      metadata_labels: ${{ steps.metadata.outputs.labels }}
+      metadata_tags: ${{ steps.metadata.outputs.tags }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -38,14 +41,31 @@ jobs:
               - 'sdkconfig.defaults'
               - 'spiffs/**'
 
+      - name: extract metadata
+        id: metadata
+        uses: docker/metadata-action@v4
+        with:
+          images: "ghcr.io/${{ github.repository }}"
+          tags: |
+            type=ref,event=tag
+            type=ref,event=pr
+            type=ref,event=branch
+
+      - name: debug
+        run: echo "${{ steps.metadata.outputs.json }}"
+
   build_container:
     if: ${{ needs.trigger_workflow.outputs.container_any_changed == 'true' || github.ref_type == 'tag' }}
     uses: ./.github/workflows/build-container.yml
     needs: trigger_workflow
+    with:
+      container-image: ${{ fromJSON(needs.trigger_workflow.outputs.metadata_json).tags[0] }}
+      labels: ${{ needs.trigger_workflow.outputs.metadata_labels }}
+      tags: ${{ needs.trigger_workflow.outputs.metadata_tags }}
 
   build_willow:
     if: ${{ needs.trigger_workflow.outputs.container_any_changed == 'false' && needs.trigger_workflow.outputs.image_any_changed == 'true' }}
     uses: ./.github/workflows/build-willow.yml
     needs: trigger_workflow
     with:
-      container-image: ghcr.io/toverainc/willow:main
+      container-image: ${{ fromJSON(needs.trigger_workflow.outputs.metadata_json).tags[0] }}


### PR DESCRIPTION
When a commit doesn't trigger a container build, we build Willow in the container tagged main. If in a previous commit in the current branch or PR we made changes that actually require a container rebuild, CI can fail, as one of the Espressif frameworks could be out of date.

Fix this by moving the metadata extraction out of the build-container workflow into the meta workflow and use its outputs an inputs for the build workflows.