### PR TITLE
Revert "hass: fix potential memory leak"

### DIFF
--- a/main/endpoint/hass.c
+++ b/main/endpoint/hass.c
@@ -162,13 +162,13 @@ end:
                     lvgl_port_unlock();
                 }
 
-                reset_timer(hdl_display_timer, DISPLAY_TIMEOUT_US, false);
-
-cleanup:
                 if (hir.has_speech) {
                     free(hir.speech);
                 }
 
+                reset_timer(hdl_display_timer, DISPLAY_TIMEOUT_US, false);
+
+cleanup:
                 cJSON_Delete(cjson);
                 free(resp);
             }


### PR DESCRIPTION
The fix for the potential leak can cause a null pointer deref crash.

This reverts commit de1e99f07a1b15f73227305149c39a98cd4598c0.