### PR TITLE
Support the GT911 touch controller in the ESP32-S3-Box-3 final version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY container.gitconfig /root/.gitconfig
 ENV PATH="$PATH:/willow/.local/bin"
 WORKDIR /willow
 
-ENV ADF_VER="willow-main-2023092800"
+ENV ADF_VER="willow-main-2023102800"
 RUN \
     cd /opt/esp/idf && \
     curl https://raw.githubusercontent.com/toverainc/esp-adf/$ADF_VER/idf_patches/idf_v5.1_freertos.patch | patch -p1

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -11,6 +11,12 @@ dependencies:
       service_url: https://api.components.espressif.com/
       type: service
     version: 1.1.0
+  espressif/esp_lcd_touch_gt911:
+    component_hash: 20ac25d1439dbe177764dbed9cd868388fecb052380b5349f2e9e370013ca76a
+    source:
+      service_url: https://api.components.espressif.com/
+      type: service
+    version: 1.1.0
   espressif/esp_lcd_touch_tt21100:
     component_hash: 3670f6f3d68c120d680d70ffdf2dc10f6c2a5bea8c0e87521fb92ac2af1f94c5
     source:
@@ -46,6 +52,6 @@ dependencies:
       service_url: https://api.components.espressif.com/
       type: service
     version: 8.3.9
-manifest_hash: 16e419349385001148c6e6d82b3ab837b2e2869753a81d6fe4ea5f77b9ec754e
+manifest_hash: 026d2c1ee13599f6e9792b979b276491d4aacc16c125a234ca36a647dda816a1
 target: esp32s3
 version: 1.0.0

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -1,5 +1,6 @@
 ## IDF Component Manager Manifest File
 dependencies:
+  espressif/esp_lcd_touch_gt911: "1.1.0"
   lvgl/lvgl: "8.3.9"
   espressif/esp_websocket_client: "1.1.0"
   espressif/nghttp: "1.52.0"

--- a/main/system.c
+++ b/main/system.c
@@ -1,3 +1,4 @@
+#include "board.h"
 #include "esp_event.h"
 #include "esp_log.h"
 #include "esp_lvgl_port.h"
@@ -19,6 +20,7 @@ static const char *willow_hw_t[WILLOW_HW_MAX] = {
     [WILLOW_HW_ESP32_S3_BOX_3] = "ESP32-S3-BOX-3",
 };
 
+i2c_bus_handle_t hdl_i2c_bus;
 volatile bool restarting = false;
 
 const char *str_hw_type(int id)
@@ -52,9 +54,26 @@ static esp_err_t init_ev_loop()
     return ret;
 }
 
+static void init_i2c(void)
+{
+    int ret = ESP_OK;
+    i2c_config_t i2c_cfg = {
+        .mode = I2C_MODE_MASTER,
+        .sda_pullup_en = GPIO_PULLUP_ENABLE,
+        .scl_pullup_en = GPIO_PULLUP_ENABLE,
+        .master.clk_speed = 100000,
+    };
+    ret = get_i2c_pins(I2C_NUM_0, &i2c_cfg);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "failed to get I2C pins");
+    }
+    hdl_i2c_bus = i2c_bus_create(I2C_NUM_0, &i2c_cfg);
+}
+
 void init_system(void)
 {
     set_hw_type();
+    init_i2c();
     ESP_ERROR_CHECK(init_ev_loop());
 }
 

--- a/main/system.h
+++ b/main/system.h
@@ -1,4 +1,5 @@
 #include "esp_peripherals.h"
+#include "i2c_bus.h"
 
 enum willow_hw_t {
     WILLOW_HW_UNSUPPORTED = 0,
@@ -18,6 +19,7 @@ enum willow_state {
 extern enum willow_hw_t hw_type;
 extern enum willow_state state;
 extern esp_periph_set_handle_t hdl_pset;
+extern i2c_bus_handle_t hdl_i2c_bus;
 
 extern volatile bool restarting;
 


### PR DESCRIPTION
The pre-production units of the ESP32-S3-Box-3 uses a different touch
controller than the final model. Detect the model to make sure the touch
controller works on both versions.