### PR TITLE
Dockerfile: bump ESP-ADF to revert accidental changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY container.gitconfig /root/.gitconfig
 ENV PATH="$PATH:/willow/.local/bin"
 WORKDIR /willow
 
-ENV ADF_VER="willow-main-2023110700"
+ENV ADF_VER="willow-main-2023110800"
 RUN \
     cd /opt/esp/idf && \
     curl https://raw.githubusercontent.com/toverainc/esp-adf/$ADF_VER/idf_patches/idf_v5.1_freertos.patch | patch -p1


### PR DESCRIPTION
The willow-main-2023110700 tag in our ESP-ADF fork contains some accidental changes to the git submodules.