### PR TITLE
Fix session timer

### DIFF
--- a/main/audio.c
+++ b/main/audio.c
@@ -315,8 +315,7 @@ static esp_err_t cb_ar_event(audio_rec_evt_t *are, void *data)
             speech_rec_mode = config_get_char("speech_rec_mode", DEFAULT_SPEECH_REC_MODE);
 
             if (strcmp(speech_rec_mode, "WIS") == 0) {
-                reset_timer(hdl_sess_timer, config_get_int("stream_timeout", DEFAULT_STREAM_TIMEOUT) * 1000 * 1000,
-                            false);
+                reset_timer(hdl_sess_timer, config_get_int("stream_timeout", DEFAULT_STREAM_TIMEOUT), false);
             }
             if (lvgl_port_lock(lvgl_lock_timeout)) {
                 lv_obj_add_flag(lbl_ln1, LV_OBJ_FLAG_HIDDEN);


### PR DESCRIPTION
In commit 349a8e47ebe7 ("treewide: define display timeout in seconds"), we changed reset_timer to convert the timeout to microseconds inside the function, but we forgot to change the reset_timer call for the session timer. As a result, the session timer was waiting for millions of seconds rather than just the number of seconds in the config.

Fixes: 349a8e47ebe7 ("treewide: define display timeout in seconds")