### PR TITLE
WIS TTS URL v2 support

### DIFF
--- a/main/audio.c
+++ b/main/audio.c
@@ -99,14 +99,26 @@ void play_audio_ok(void *data)
 
 static void play_audio_wis_tts(void *data)
 {
+    char *url = NULL;
+    char *wis_tts_url = NULL;
+
     if (data == NULL) {
         ESP_LOGW(TAG, "called play_audio_wis_tts with NULL data");
         return;
     }
-    char *wis_tts_url = config_get_char("wis_tts_url", DEFAULT_WIS_TTS_URL);
-    int len_url = strlen(wis_tts_url) + strlen(WIS_URL_TTS_ARG) + strlen((char *)data) + 1;
-    char *url = calloc(sizeof(char), len_url);
-    snprintf(url, len_url, "%s%s%s", wis_tts_url, WIS_URL_TTS_ARG, (char *)data);
+
+    wis_tts_url = config_get_char("wis_tts_url_v2", NULL);
+    if (wis_tts_url != NULL) {
+        int len_url = strlen(wis_tts_url) + strlen((char *)data) + 1;
+        url = calloc(sizeof(char), len_url);
+        snprintf(url, len_url, "%s%s", wis_tts_url, (char *)data);
+    } else {
+        wis_tts_url = config_get_char("wis_tts_url", DEFAULT_WIS_TTS_URL);
+        int len_url = strlen(wis_tts_url) + strlen(WIS_URL_TTS_ARG) + strlen((char *)data) + 1;
+        url = calloc(sizeof(char), len_url);
+        snprintf(url, len_url, "%s%s%s", wis_tts_url, WIS_URL_TTS_ARG, (char *)data);
+    }
+
     free(wis_tts_url);
     gpio_set_level(get_pa_enable_gpio(), 1);
     ESP_LOGI(TAG, "Using WIS TTS URL '%s'", url);

--- a/main/config.c
+++ b/main/config.c
@@ -81,7 +81,7 @@ char *config_get_char(const char *key, const char *default_value)
     if (val != NULL && cJSON_IsString(val) && val->valuestring != NULL) {
         ret = strndup(val->valuestring, strlen(val->valuestring));
     } else {
-        ret = strndup(default_value, strlen(default_value));
+        ret = default_value == NULL ? NULL : strndup(default_value, strlen(default_value));
     }
     ESP_LOGD(TAG, "config_get_char(%s): %s", key, ret);
     return ret;


### PR DESCRIPTION
To have more flexibility with the new Coqui TTS backend, we're going to
construct the TTS URL in WAS before sending it to Willow.

We will support both the old and the new way for a while, both in Willow
and WAS, so that old Willow versions will work with new WAS versions,
and new Willow version will work with old WAS versions.