### PR TITLE
Improve HTTP stream timeout error handling

### DIFF
--- a/main/audio.c
+++ b/main/audio.c
@@ -60,9 +60,10 @@
 #define DEFAULT_WIS_URL             "https://infer.tovera.io/api/willow"
 
 #define HTTP_STREAM_TIMEOUT_MS 2 * 1000
-#define MULTINET_TWDT          30
-#define STR_WAKE_LEN           25
-#define WIS_URL_TTS_ARG        "?format=WAV&speaker=CLB&text="
+
+#define MULTINET_TWDT   30
+#define STR_WAKE_LEN    25
+#define WIS_URL_TTS_ARG "?format=WAV&speaker=CLB&text="
 
 typedef enum willow_http_stream {
     WILLOW_HS_ESP_AUDIO,

--- a/main/audio.c
+++ b/main/audio.c
@@ -532,7 +532,11 @@ static esp_err_t hdl_ev_hs_to_api(http_stream_event_msg_t *msg)
             // Check status code
             int http_status = esp_http_client_get_status_code(http);
             if (http_status != 200) {
-                if (http_status == 401) {
+                // when ESP HTTP Client terminates connection due to timeout we get -1
+                if (http_status == -1) {
+                    ESP_LOGE(TAG, "WIS response took longer than %dms, connection aborted", HTTP_STREAM_TIMEOUT_MS);
+                    ui_pr_err("WIS timeout", "Check server performance");
+                } else if (http_status == 401) {
                     ESP_LOGE(TAG, "WIS returned Unauthorized Access (HTTP 401)");
                     ui_pr_err("WIS auth failed", "Check server & settings");
                 } else if (http_status == 406) {

--- a/main/audio.c
+++ b/main/audio.c
@@ -59,7 +59,8 @@
 #define DEFAULT_WIS_TTS_URL         "https://infer.tovera.io/api/tts"
 #define DEFAULT_WIS_URL             "https://infer.tovera.io/api/willow"
 
-#define HTTP_STREAM_TIMEOUT_MS 2 * 1000
+#define HTTP_STREAM_TIMEOUT_MS              2 * 1000
+#define HTTP_STREAM_TIMEOUT_MS_POST_REQUEST 10 * 1000
 
 #define MULTINET_TWDT   30
 #define STR_WAKE_LEN    25
@@ -519,6 +520,7 @@ static esp_err_t hdl_ev_hs_to_api(http_stream_event_msg_t *msg)
 
         case HTTP_STREAM_POST_REQUEST:
             ESP_LOGI(TAG, "WIS HTTP client HTTP_STREAM_POST_REQUEST, write end chunked marker");
+            esp_http_client_set_timeout_ms(http, HTTP_STREAM_TIMEOUT_MS_POST_REQUEST);
             if (esp_http_client_write(http, "0\r\n\r\n", 5) <= 0) {
                 return ESP_FAIL;
             }


### PR DESCRIPTION
And increase the HTTP timeout after initial connect to 10s to accommodate users trying WIS on a slow GPU or CPU within reason.