### PR TITLE
audio: only install I2S driver once

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY container.gitconfig /root/.gitconfig
 ENV PATH="$PATH:/willow/.local/bin"
 WORKDIR /willow
 
-ENV ADF_VER="willow-main-2023110800"
+ENV ADF_VER="willow-main-2024010200"
 RUN \
     cd /opt/esp/idf && \
     curl https://raw.githubusercontent.com/toverainc/esp-adf/$ADF_VER/idf_patches/idf_v5.1_freertos.patch | patch -p1

--- a/main/audio.c
+++ b/main/audio.c
@@ -290,6 +290,7 @@ static void init_esp_audio(void)
             .use_apll = false, // not supported on ESP32-S3-BOX
         },
         .i2s_port = CODEC_ADC_I2S_PORT,
+        .install_drv = true,
         .multi_out_num = 0,
         .need_expand = true,
         .out_rb_size = 8 * 1024, // default is 8 * 1024
@@ -682,6 +683,7 @@ static void start_rec(void)
             .use_apll = false,	// not supported on ESP32-S3-BOX
         },
         .i2s_port = CODEC_ADC_I2S_PORT,
+        .install_drv = false,
         .multi_out_num = 0,
         .need_expand = false,
         .out_rb_size = 8 * 1024, // default is 8 * 1024


### PR DESCRIPTION
This requires an ESP-ADF bump.

Closes: #125
Closes: #354