### PR TITLE
build: make MultiNet support opt-in

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,8 @@ cmake_minimum_required(VERSION 3.5)
 
 set(COMPONENTS main)
 
-if($ENV{CI})
-    message("CI detected, disabling MultiNet support")
-else()
+if($ENV{MULTINET})
+    message("Enabling MultiNet support. Please note we will not provide support. Issues related to MultiNet will be closed without resolution.")
     add_definitions(-DWILLOW_SUPPORT_MULTINET)
 endif()
 

--- a/utils.sh
+++ b/utils.sh
@@ -244,7 +244,7 @@ fullclean)
 build)
     check_container
     check_deps
-    [ "$CI" ] || generate_speech_commands
+    [ "$MULTINET" ] && generate_speech_commands
     if [ $2 ]; then
         echo "Adding timestamp to dev build"
         TS=$(date '+%d-%m-%Y_%H:%M:%S')


### PR DESCRIPTION
We haven't supported MultiNet in any of the Willow or WAS releases. Let's make it opt-in, rather than disabling it in CI builds. This will solve the missing generated_cmd_multinet.h file for people trying to build manually.

It is still possible to enable MultiNet when building manually by setting the MULTINET environment variable, but we will not provide support for any issues related to it. Issues will be closed without resolution.

Closes: #382