### PR TITLE
Implement i2c_probe function

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -6,6 +6,7 @@ set(COMPONENT_SRCS
     "endpoint/openhab.c"
     "endpoint/rest.c"
     "http.c"
+    "i2c.c"
     "input.c"
     "log.c"
     "lv_img_hand_left.c"

--- a/main/i2c.c
+++ b/main/i2c.c
@@ -1,4 +1,28 @@
+#include "board.h"
+#include "esp_log.h"
+#include "i2c_bus.h"
+
 #include "i2c.h"
+
+static const char *TAG = "WILLOW/I2C";
+
+i2c_bus_handle_t hdl_i2c_bus;
+
+void init_i2c(void)
+{
+    int ret = ESP_OK;
+    i2c_config_t i2c_cfg = {
+        .mode = I2C_MODE_MASTER,
+        .sda_pullup_en = GPIO_PULLUP_ENABLE,
+        .scl_pullup_en = GPIO_PULLUP_ENABLE,
+        .master.clk_speed = 100000,
+    };
+    ret = get_i2c_pins(I2C_NUM_0, &i2c_cfg);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "failed to get I2C pins");
+    }
+    hdl_i2c_bus = i2c_bus_create(I2C_NUM_0, &i2c_cfg);
+}
 
 esp_err_t i2c_probe(i2c_port_t port, uint8_t addr)
 {

--- a/main/i2c.c
+++ b/main/i2c.c
@@ -1,0 +1,16 @@
+#include "i2c.h"
+
+esp_err_t i2c_probe(i2c_port_t port, uint8_t addr)
+{
+    esp_err_t ret = ESP_ERR_NOT_FOUND;
+
+    i2c_cmd_handle_t hdl_i2c_cmd = i2c_cmd_link_create();
+    i2c_master_start(hdl_i2c_cmd);
+    i2c_master_write_byte(hdl_i2c_cmd, (addr << 1) | I2C_MASTER_WRITE, I2C_MASTER_ACK);
+    i2c_master_stop(hdl_i2c_cmd);
+
+    ret = i2c_master_cmd_begin(port, hdl_i2c_cmd, 5000 / portTICK_PERIOD_MS);
+    i2c_cmd_link_delete(hdl_i2c_cmd);
+
+    return ret;
+}

--- a/main/i2c.h
+++ b/main/i2c.h
@@ -1,3 +1,4 @@
 #include "driver/i2c.h"
 
+void init_i2c(void);
 esp_err_t i2c_probe(i2c_port_t port, uint8_t addr);

--- a/main/i2c.h
+++ b/main/i2c.h
@@ -1,0 +1,3 @@
+#include "driver/i2c.h"
+
+esp_err_t i2c_probe(i2c_port_t port, uint8_t addr);

--- a/main/slvgl.c
+++ b/main/slvgl.c
@@ -7,13 +7,13 @@
 #include "esp_log.h"
 #include "esp_lvgl_port.h"
 #include "esp_timer.h"
-#include "i2c_bus.h"
 #include "lvgl.h"
 #include "periph_lcd.h"
 
 #include "audio.h"
 #include "config.h"
 #include "display.h"
+#include "i2c.h"
 #include "system.h"
 #include "timer.h"
 
@@ -176,13 +176,13 @@ esp_err_t init_lvgl_touch(void)
 
     esp_lcd_panel_io_i2c_config_t cfg_io_lt;
 
-    if (i2c_bus_probe_addr(hdl_i2c_bus, ESP_LCD_TOUCH_IO_I2C_GT911_ADDRESS << 1) == ESP_OK) {
+    if (i2c_probe(I2C_NUM_0, ESP_LCD_TOUCH_IO_I2C_GT911_ADDRESS) == ESP_OK) {
         cfg_io_lt = cfg_lpiic_gt911(ESP_LCD_TOUCH_IO_I2C_GT911_ADDRESS);
         touch_type = TOUCH_GT911;
-    } else if (i2c_bus_probe_addr(hdl_i2c_bus, ESP_LCD_TOUCH_IO_I2C_GT911_ADDRESS_BACKUP << 1) == ESP_OK) {
+    } else if (i2c_probe(I2C_NUM_0, ESP_LCD_TOUCH_IO_I2C_GT911_ADDRESS_BACKUP) == ESP_OK) {
         cfg_io_lt = cfg_lpiic_gt911(ESP_LCD_TOUCH_IO_I2C_GT911_ADDRESS_BACKUP);
         touch_type = TOUCH_GT911;
-    } else if (i2c_bus_probe_addr(hdl_i2c_bus, ESP_LCD_TOUCH_IO_I2C_TT21100_ADDRESS << 1) == ESP_OK) {
+    } else if (i2c_probe(I2C_NUM_0, ESP_LCD_TOUCH_IO_I2C_TT21100_ADDRESS) == ESP_OK) {
         cfg_io_lt = cfg_lpiic_tt21100();
         cfg_lt.flags.mirror_x = true;
         touch_type = TOUCH_TT21100;

--- a/main/system.c
+++ b/main/system.c
@@ -1,4 +1,3 @@
-#include "board.h"
 #include "esp_event.h"
 #include "esp_log.h"
 #include "esp_lvgl_port.h"
@@ -8,6 +7,7 @@
 #include "lvgl.h"
 #include "sdkconfig.h"
 
+#include "i2c.h"
 #include "shared.h"
 #include "slvgl.h"
 #include "system.h"
@@ -20,7 +20,6 @@ static const char *willow_hw_t[WILLOW_HW_MAX] = {
     [WILLOW_HW_ESP32_S3_BOX_3] = "ESP32-S3-BOX-3",
 };
 
-i2c_bus_handle_t hdl_i2c_bus;
 volatile bool restarting = false;
 
 const char *str_hw_type(int id)
@@ -52,22 +51,6 @@ static esp_err_t init_ev_loop()
         ESP_LOGE(TAG, "failed to initialize default event loop: %s", esp_err_to_name(ret));
     }
     return ret;
-}
-
-static void init_i2c(void)
-{
-    int ret = ESP_OK;
-    i2c_config_t i2c_cfg = {
-        .mode = I2C_MODE_MASTER,
-        .sda_pullup_en = GPIO_PULLUP_ENABLE,
-        .scl_pullup_en = GPIO_PULLUP_ENABLE,
-        .master.clk_speed = 100000,
-    };
-    ret = get_i2c_pins(I2C_NUM_0, &i2c_cfg);
-    if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "failed to get I2C pins");
-    }
-    hdl_i2c_bus = i2c_bus_create(I2C_NUM_0, &i2c_cfg);
 }
 
 void init_system(void)

--- a/main/system.h
+++ b/main/system.h
@@ -1,5 +1,4 @@
 #include "esp_peripherals.h"
-#include "i2c_bus.h"
 
 enum willow_hw_t {
     WILLOW_HW_UNSUPPORTED = 0,
@@ -19,7 +18,6 @@ enum willow_state {
 extern enum willow_hw_t hw_type;
 extern enum willow_state state;
 extern esp_periph_set_handle_t hdl_pset;
-extern i2c_bus_handle_t hdl_i2c_bus;
 
 extern volatile bool restarting;
 


### PR DESCRIPTION
And use it to probe for the I2C addresses of touch controllers used in
the ESP32-S3-Box variants supported by Willow. This is in preparation of
switching back to upstream ESP-ADF instead of our fork.

The i2c_bus_probe_addr function in ESP-ADF's i2c_bus driver rejects
addresses that use more than 7 bits, but does not set bit 8 to indicate
that we want to write from master to slave.