### PR TITLE
CI: detect changed files since last remote commit

### DIFF
--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -41,6 +41,7 @@ jobs:
               - 'partitions_willow.csv'
               - 'sdkconfig.defaults'
               - 'spiffs/**'
+          since_last_remote_commit: true
 
       - name: extract metadata
         id: metadata


### PR DESCRIPTION
When we're pushing multiple commits, the changed-files actions only looks at the last commit. This can result in building Willow source code that requires a new build container without a new build container being built. Enable since_last_remote_commit in the changed-files actions to hopefully fix this. Unfortunately, since Github actions only looks at files in the main branch, we cannot test this before merging it into the main branch.