### PR TITLE
CI: don't trigger workflow on push

### DIFF
--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -6,7 +6,6 @@ env:
 
 on:
   pull_request:
-  push:
 
 jobs:
   trigger_workflow:


### PR DESCRIPTION
Commit 2fce5e732f1c ("CI: detect changed files since last remote commit") only fixed the problem when triggering worklfow on a pull request event. The PR to bump ESP-IDF to v5.2.3 still has failing checks due to the build triggered by the push event not rebuilding the build container first, so it fails because it's building with ESP-IDF v5.1.6 while the manifest file now has a dependency on >= 5.2.0.

There appear to be some solutions to skip building on push when a pull request exists for the branch that is being pushed to, but it requires some vague conditions. This all just feels like a hack for something that should imo be basic functionality. Let's just disable the push trigger and be done with it.