### PR TITLE
build: bump esp-sr to 1.9.5

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -13,7 +13,7 @@ export DOCKER_NAME="willow-build"
 export DIST_FILE="build/${dist_filename:-willow-dist.bin}"
 
 # ESP-SR Componenent ver hash
-ESP_SR_VER="c8bf7cd118c437b4ab41ccb37e4ad6b84a8a4fc4"
+ESP_SR_VER="v1.9.5"
 
 # esptool ver to install
 ESPTOOL_VER="4.5.1"


### PR DESCRIPTION
This is the last version of esp-sr v1.

Torture test results: 1000/1000.