### PR TITLE
network: print ev_base when logging unhandled event

### DIFF
--- a/main/network.c
+++ b/main/network.c
@@ -140,7 +140,7 @@ static void hdlr_ev(void *arg, esp_event_base_t ev_base, int32_t ev_id, void *da
         return;
     }
 
-    ESP_LOGI(TAG, "unhandled network event ev_id='%" PRId32 "'", ev_id);
+    ESP_LOGI(TAG, "unhandled network event ev_base='%s' ev_id='%" PRId32 "'", ev_base, ev_id);
 }
 
 #ifndef CONFIG_WILLOW_ETHERNET


### PR DESCRIPTION
The ev_id value on its own is pretty useless without ev_base, as the event handler is register for both IP_EVENT and WIFI_EVENT.

Before:

I (18:32:27.019) WILLOW/NETWORK: unhandled network event ev_id='4'

After:

I (18:36:19.211) WILLOW/NETWORK: unhandled network event ev_base='WIFI_EVENT' ev_id='4'

Now we can `git grep WIFI_EVENT` in ESP-IDF, which learns us that the event is coming from the esp_wifi component, and that the events are defined in `components/esp_wifi/include/esp_wifi_types.h`

In that file, we can find that ev_id 4 is WIFI_EVENT_STA_CONNECTED, which triggers when the station connected to the AP.

This particular event is expected to occur, so we might consider silencing it, or logging it with a human readable message.