### PR TITLE
CI: trigger workflow on push again

### DIFF
--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -6,6 +6,12 @@ env:
 
 on:
   pull_request:
+  push:
+    branches:
+      - 'main'
+      - 'release/**'
+    tag:
+      - '*'
 
 jobs:
   trigger_workflow:

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,3 +31,4 @@ ENV ADF_VER="v2.7"
 RUN \
     cd /opt/esp/idf && \
     curl https://raw.githubusercontent.com/espressif/esp-adf/$ADF_VER/idf_patches/idf_v5.2_freertos.patch | patch -p1
+


### PR DESCRIPTION
If we don't trigger workflow on push, we will not build and push a new container image when a PR is merged. Because of this, the container image with the main tag is currently based on ESP-IDF v5.1, while we already have code in the main branch that requires ESP-IDF v5.2.

Trigger workflow on push again, but only for the main and release branches.

Also add an empty newline to Dockerfile to make sure we trigger container build and push, so that the container image with the main tag will be based on ESP-IDF v5.2.

Fixes: 390533f1c51a ("CI: don't trigger workflow on push")