### PR TITLE
idf: bump esp_websocket_client component to 1.4.0

### DIFF
--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -2,7 +2,7 @@
 dependencies:
   espressif/esp_lcd_touch_gt911: "1.1.2"
   lvgl/lvgl: "8.3.9"
-  espressif/esp_websocket_client: "1.1.0"
+  espressif/esp_websocket_client: "1.4.0"
   espressif/nghttp: "1.52.0"
   espressif/esp_lcd_touch_tt21100: "1.1.1"
   espressif/esp_lvgl_port: "1.3.0"

--- a/main/was.c
+++ b/main/was.c
@@ -358,11 +358,11 @@ void was_deinit_task(void *data)
     ret = esp_websocket_client_close(hdl_wc, 5000 / portTICK_PERIOD_MS);
     if (ret != ESP_OK) {
         ESP_LOGE(TAG, "failed to cleanly close WebSocket client");
-    }
 
-    ret = esp_websocket_client_stop(hdl_wc);
-    if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "failed to stop WebSocket client: %s", esp_err_to_name(ret));
+        ret = esp_websocket_client_stop(hdl_wc);
+        if (ret != ESP_OK) {
+            ESP_LOGE(TAG, "failed to stop WebSocket client: %s", esp_err_to_name(ret));
+        }
     }
 
     vTaskDelete(NULL);


### PR DESCRIPTION
This is the current most recent version of esp_websocket_client.

Torture test results: 1000/1000.