### PR TITLE
Dockerfile: bump ESP-IDF to v5.2.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM espressif/idf:v5.2.3
+FROM espressif/idf:v5.2.5
 
 ARG DEBIAN_FRONTEND="noninteractive"
 


### PR DESCRIPTION
This is the current most recent version of ESP-IDF 5.2.

Torture test results: 1000/1000.