### PR TITLE
CI: fix error in download-artifact action

### DIFF
--- a/.github/workflows/build-willow.yml
+++ b/.github/workflows/build-willow.yml
@@ -107,6 +107,8 @@ jobs:
     steps:
       - name: download artifacts
         uses: actions/download-artifact@v4
+        with:
+          pattern: '!*.dockerbuild'
 
       - name: pwd
         run: pwd


### PR DESCRIPTION
The download-artifact action tries to download all artifacts, but fails if an artifact is not in zip format. At some point something decided to start uploading Docker build summary, which is not in zip format, causing this problem.

[Insert rant about Github Actions here]

https://github.com/actions/toolkit/pull/1874#pullrequestreview-2655200101