### PR TITLE
audio: set HTTP stream timeout after connect

### DIFF
--- a/main/audio.c
+++ b/main/audio.c
@@ -556,6 +556,7 @@ static esp_err_t hdl_ev_hs_to_api(http_stream_event_msg_t *msg)
             return ESP_OK;
 
         case HTTP_STREAM_ON_REQUEST:
+            esp_http_client_set_timeout_ms(http, HTTP_STREAM_TIMEOUT_MS_POST_REQUEST);
             wlen = sprintf(len_buf, "%x\r\n", msg->buffer_len);
             if (esp_http_client_write(http, len_buf, wlen) <= 0) {
                 return ESP_FAIL;
@@ -572,7 +573,6 @@ static esp_err_t hdl_ev_hs_to_api(http_stream_event_msg_t *msg)
 
         case HTTP_STREAM_POST_REQUEST:
             ESP_LOGI(TAG, "WIS HTTP client HTTP_STREAM_POST_REQUEST, write end chunked marker");
-            esp_http_client_set_timeout_ms(http, HTTP_STREAM_TIMEOUT_MS_POST_REQUEST);
             if (esp_http_client_write(http, "0\r\n\r\n", 5) <= 0) {
                 return ESP_FAIL;
             }


### PR DESCRIPTION
In commit 67ff0351b741 ("audio: increase HTTP stream timeout after send") we increased the timeout for the HTTP stream to WIS STT after send to 10s, to allow people with slow WIS to still use Willow. For some reason this worked in the 0.3 releases, but it seems this doesn't work anymore after all the bumps of Espressif components in the 0.4 releases.

The commit was wrong in the first place, as we should increase the timeout after initial connect, but before we finish sending, as setting it after we finished sending should result in the connection timing out after 2s while sending.

Set the timeout on the HTTP_STREAM_ON_REQUEST event to fix this.

Fixes: 67ff0351b741 ("audio: increase HTTP stream timeout after send")