### PR TITLE
Docker: bump ESP-IDF to 5.3.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM espressif/idf:v5.3.3
+FROM espressif/idf:v5.3.4
 
 ARG DEBIAN_FRONTEND="noninteractive"
 


### PR DESCRIPTION
This is the current most recent version of ESP-IDF 5.3.